### PR TITLE
fix: reset RecoilController on weapon swap

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/HandData.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/HandData.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 public class HandData {
 
@@ -317,7 +318,19 @@ public class HandData {
         return currentWeaponTitle;
     }
 
+    /**
+     * Sets the current weapon title tracked for this hand.
+     * When the title actually changes, we hard-reset the player's RecoilController state
+     * so the next shot starts from zero (no carry-over from the previous weapon).
+     */
     public void setCurrentWeaponTitle(String currentWeaponTitle) {
+        // Only react on real changes
+        boolean changed = !Objects.equals(this.currentWeaponTitle, currentWeaponTitle);
+
         this.currentWeaponTitle = currentWeaponTitle;
+
+        if (changed && entityWrapper instanceof PlayerWrapper pw) {
+            pw.getRecoilController().hardReset();
+        }
     }
 }


### PR DESCRIPTION
Problem
- Recoil state carries over between different weapons (notably on F-swap), so the first shot can “recover” to the previous gun’s peak before applying the new gun’s recoil.

Root cause
- RecoilController keeps accumulated/target/residual recoil across weapon changes; there’s no reset hook.

Changes
- Add RecoilController#hardReset() with a volatile flag.
- Clear current/target/residual when the flag is seen (in accept() and onShotFired()).
- Call hardReset() from HandData#setCurrentWeaponTitle(...) when the title actually changes.

Behavior
- No change during normal firing on the same weapon.
- On weapon swap, next shot starts from zero; first-shot recoil now matches the new gun/attachments.

Test
- Fire weapon A to build recoil, F-swap to weapon B, fire: no snap-back to A’s peak; B’s first shot uses B’s recoil.