### PR TITLE
Add Preserve_Item option to ammo converter checks

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
@@ -21,12 +21,6 @@ public class AmmoConverter extends WeaponConverter {
         this.preserveItem = preserveItem;
     }
 
-    /**
-     * When <code>true</code>, matching items are tagged as ammo in-place (only the ammo NBT is added)
-     * instead of having their type/meta overwritten with the configured Bullet_Item/Magazine_Item
-     * template. Use this to allow custom items (e.g. from other plugins) to be used as ammo directly,
-     * without WeaponMechanics stripping their custom appearance/data.
-     */
     public boolean isPreserveItem() {
         return preserveItem;
     }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class AmmoConverter extends WeaponConverter {
 
+    private boolean preserveItem;
+
     /**
      * Default constructor for serializer.
      */
@@ -14,8 +16,19 @@ public class AmmoConverter extends WeaponConverter {
         super();
     }
 
-    public AmmoConverter(boolean type, boolean name, boolean lore, boolean enchantments, boolean cmd) {
+    public AmmoConverter(boolean type, boolean name, boolean lore, boolean enchantments, boolean cmd, boolean preserveItem) {
         super(type, name, lore, enchantments, cmd);
+        this.preserveItem = preserveItem;
+    }
+
+    /**
+     * When <code>true</code>, matching items are tagged as ammo in-place (only the ammo NBT is added)
+     * instead of having their type/meta overwritten with the configured Bullet_Item/Magazine_Item
+     * template. Use this to allow custom items (e.g. from other plugins) to be used as ammo directly,
+     * without WeaponMechanics stripping their custom appearance/data.
+     */
+    public boolean isPreserveItem() {
+        return preserveItem;
     }
 
     @Override
@@ -32,6 +45,7 @@ public class AmmoConverter extends WeaponConverter {
         boolean lore = data.of("Lore").getBool().orElse(false);
         boolean enchantments = data.of("Enchantments").getBool().orElse(false);
         boolean cmd = data.of("Custom_Model_Data").getBool().orElse(false);
+        boolean preserveItem = data.of("Preserve_Item").getBool().orElse(false);
 
         if (!type && !name && !lore && !enchantments && !cmd) {
             throw data.exception(null, "'Type', 'Name', 'Lore', 'Enchantments', 'Custom_Model_Data' are all 'false'",
@@ -39,6 +53,6 @@ public class AmmoConverter extends WeaponConverter {
                 "If you want to remove the ammo conversion feature, remove the 'Ammo_Converter_Check' option from config");
         }
 
-        return new AmmoConverter(type, name, lore, enchantments, cmd);
+        return new AmmoConverter(type, name, lore, enchantments, cmd, preserveItem);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/ItemAmmo.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/ItemAmmo.java
@@ -72,20 +72,28 @@ public class ItemAmmo implements IAmmoType {
 
             // Determine if this item matches the bullet template, or the
             // magazine template (or neither).
-            ItemStack ammoTemplate = null;
-            if (bulletItem != null && ammoConverter.isMatch(potentialAmmo, bulletItem))
-                ammoTemplate = bulletItem.clone();
-            if (magazineItem != null && ammoConverter.isMatch(potentialAmmo, magazineItem))
-                ammoTemplate = magazineItem.clone();
+            boolean matchesBullet = bulletItem != null && ammoConverter.isMatch(potentialAmmo, bulletItem);
+            boolean matchesMagazine = !matchesBullet && magazineItem != null && ammoConverter.isMatch(potentialAmmo, magazineItem);
 
             // Item did not match either of the ammo templates, skip it.
-            if (ammoTemplate == null)
+            if (!matchesBullet && !matchesMagazine)
                 continue;
 
-            // Handle conversion
-            potentialAmmo.setType(ammoTemplate.getType());
-            potentialAmmo.setItemMeta(ammoTemplate.getItemMeta());
-            AdventureUtil.updatePlaceholders(wrapper.getPlayer(), potentialAmmo);
+            if (ammoConverter.isPreserveItem()) {
+                // Only tag the item as ammo, keeping its original type/meta (name, lore,
+                // custom model data, other plugins' NBT, etc.) completely untouched. This
+                // allows custom items (e.g. from item plugins like Nexo) to be used as
+                // ammo directly, without being replaced by the configured template item.
+                CustomTag.AMMO_TITLE.setString(potentialAmmo, ammoTitle);
+                if (matchesMagazine)
+                    CustomTag.AMMO_MAGAZINE.setInteger(potentialAmmo, 1);
+            } else {
+                // Handle conversion
+                ItemStack ammoTemplate = matchesMagazine ? magazineItem.clone() : bulletItem.clone();
+                potentialAmmo.setType(ammoTemplate.getType());
+                potentialAmmo.setItemMeta(ammoTemplate.getItemMeta());
+                AdventureUtil.updatePlaceholders(wrapper.getPlayer(), potentialAmmo);
+            }
 
             inventory.setItem(i, potentialAmmo);
             hasAmmo = true;

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/ItemAmmo.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/ItemAmmo.java
@@ -80,10 +80,6 @@ public class ItemAmmo implements IAmmoType {
                 continue;
 
             if (ammoConverter.isPreserveItem()) {
-                // Only tag the item as ammo, keeping its original type/meta (name, lore,
-                // custom model data, other plugins' NBT, etc.) completely untouched. This
-                // allows custom items (e.g. from item plugins like Nexo) to be used as
-                // ammo directly, without being replaced by the configured template item.
                 CustomTag.AMMO_TITLE.setString(potentialAmmo, ammoTitle);
                 if (matchesMagazine)
                     CustomTag.AMMO_MAGAZINE.setInteger(potentialAmmo, 1);


### PR DESCRIPTION
## Summary
- Adds a new `Preserve_Item` boolean option under `Item_Ammo.Ammo_Converter_Check`.
- When `true`, an item matching the converter's Type/Name/Lore/Custom_Model_Data/Enchantments criteria is only tagged with the internal ammo NBT (and magazine NBT, if it matched the magazine template) — its type and item meta are left completely untouched.
- When omitted/`false`, behavior is unchanged from current (the matching item's type/meta is overwritten with the configured Bullet_Item/Magazine_Item template).

`Preserve_Item: true` lets these items be recognized and consumed as valid ammo directly, without WeaponMechanics ever touching their type/meta.